### PR TITLE
Clarify width override comment in resume.html

### DIFF
--- a/resume.html
+++ b/resume.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="assets/css/main.css" />
  <!-- Custom width override: limits line length to ~58 em on large screens -->
     <style>
-      /* Applies only to this page because #main.alt exists only here */
+      /* Width override for pages with #main.alt (resume, generic, powerbi-retail) */
       #main.alt .inner {
         max-width: 50em;   /* ≈ 800 px for comfy reading */
         margin: 0 auto;


### PR DESCRIPTION
## Summary
- Clarify inline comment for width override, noting it applies to pages using `#main.alt` (resume, generic, powerbi-retail).

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68a8fff660b88333b6346404aa9b4460